### PR TITLE
Fix integer bounds for Example6

### DIFF
--- a/example_defs.py
+++ b/example_defs.py
@@ -167,7 +167,7 @@ class Example6(BaseModel):
     
     @classmethod
     def generate_example(cls):
-        size_low, size_high = 100.0, 10000.0
+        size_low, size_high = 100, 10000
         time_low, time_high = 10.0, 10000.0
         size1, size2, size3 = random.randint(size_low,size_high,size=3)
         time1 = random.random()*(time_high-time_low)+time_low


### PR DESCRIPTION
## Summary
- use integer bounds when generating sample sizes in `Example6.generate_example`

## Testing
- `python -m py_compile *.py`
- `pytest -q` *(no tests found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68742b964c188333b52b12daf503edbc