### PR TITLE
Fix YAML validation check

### DIFF
--- a/simulate_examples.py
+++ b/simulate_examples.py
@@ -27,7 +27,8 @@ def generate_example_from_class(class_name,yamlstr,description_list,num_examples
         filled_description = description.format(**dict(example)) 
         if not validate_filled_description(filled_description):
             continue
-        validate_filled_yaml(filled_yaml)
+        if not validate_filled_yaml(filled_yaml):
+            continue
         current_desc_entries.append(filled_description)
         current_yaml_entries.append(filled_yaml)
     return current_desc_entries,current_yaml_entries


### PR DESCRIPTION
## Summary
- avoid adding invalid YAML entries when generating examples

## Testing
- `python -m pytest -q`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68742b964c188333b52b12daf503edbc